### PR TITLE
Fixed punctuation in output

### DIFF
--- a/process.js
+++ b/process.js
@@ -41,7 +41,15 @@ function keepGoing() {
   });
 
   rl.on('line', (line) => {
-    let lines = line.replace(/[\"”“]/g, '').split(/\||\. |\!|\?]/g);
+    let lines = line.replace(/[\"”“]/g, '')
+                    .split(/(\||\.|\!|\?) /g)
+                    .map((element, index, array) => {
+		                  if((index+1) % 2)
+  		                  return (array[index+1])? element.concat(array[index+1]) : element;
+                      else
+    	                  return ;
+                    })
+                    .filter(function(element){return element});
     lines.forEach(l => {
       if (l.startsWith('--')) {
         l = l.substr(2);


### PR DESCRIPTION
Only split by punctuation marks, if they are followed by a space.
And keep the punctuation mark intact.

I know this looks kinda horrible, but it works.
I tested it on jsfiddle only though.
(the array lines should have correct values now)

I would've done it using regularexpressions only, but wasn't able to due to missing lookbehind (currently js only supports look ahead)